### PR TITLE
Add `directoryMode` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,8 @@ declare namespace moveFile {
 		readonly overwrite?: boolean;
 
 		/**
-		Permissions for created directories.
+		
+[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories.
 
 		@default 0o777
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,13 @@ declare namespace moveFile {
 		@default true
 		*/
 		readonly overwrite?: boolean;
+
+		/**
+		Permissions for created directories.
+
+		@default 0o777
+		*/
+		readonly directoryMode?: number | string;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,7 @@ declare namespace moveFile {
 		readonly overwrite?: boolean;
 
 		/**
-		
-[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories.
+		[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories.
 
 		@default 0o777
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare namespace moveFile {
 
 		@default 0o777
 		*/
-		readonly directoryMode?: number | string;
+		readonly directoryMode?: number;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,10 @@ module.exports = async (source, destination, options) => {
 		throw new Error(`The destination file exists: ${destination}`);
 	}
 
-	await fsP.mkdir(path.dirname(destination), {recursive: true});
+	await fsP.mkdir(path.dirname(destination), {
+		recursive: true,
+		mode: options.directoryMode
+	});
 
 	try {
 		await fsP.rename(source, destination);
@@ -47,7 +50,10 @@ module.exports.sync = (source, destination, options) => {
 		throw new Error(`The destination file exists: ${destination}`);
 	}
 
-	fs.mkdirSync(path.dirname(destination), {recursive: true});
+	fs.mkdirSync(path.dirname(destination), {
+		recursive: true,
+		mode: options.directoryMode
+	});
 
 	try {
 		fs.renameSync(source, destination);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectError, expectType} from 'tsd';
 import moveFile = require('.');
 
 expectType<Promise<void>>(
@@ -12,8 +12,8 @@ expectType<Promise<void>>(
 		directoryMode: 0o700
 	})
 );
-expectType<Promise<void>>(
-	moveFile('source/unicorn.png', 'destination/unicorn.png', {
+expectError(
+	await moveFile('source/unicorn.png', 'destination/unicorn.png', {
 		directoryMode: '700'
 	})
 );
@@ -30,7 +30,7 @@ expectType<void>(
 		directoryMode: 0o700
 	})
 );
-expectType<void>(
+expectError(
 	moveFile.sync('source/unicorn.png', 'destination/unicorn.png', {
 		directoryMode: '700'
 	})

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,11 +7,31 @@ expectType<Promise<void>>(
 expectType<Promise<void>>(
 	moveFile('source/unicorn.png', 'destination/unicorn.png', {overwrite: false})
 );
+expectType<Promise<void>>(
+	moveFile('source/unicorn.png', 'destination/unicorn.png', {
+		directoryMode: 0o700
+	})
+);
+expectType<Promise<void>>(
+	moveFile('source/unicorn.png', 'destination/unicorn.png', {
+		directoryMode: '700'
+	})
+);
 expectType<void>(
 	moveFile.sync('source/unicorn.png', 'destination/unicorn.png')
 );
 expectType<void>(
 	moveFile.sync('source/unicorn.png', 'destination/unicorn.png', {
 		overwrite: false
+	})
+);
+expectType<void>(
+	moveFile.sync('source/unicorn.png', 'destination/unicorn.png', {
+		directoryMode: 0o700
+	})
+);
+expectType<void>(
+	moveFile.sync('source/unicorn.png', 'destination/unicorn.png', {
+		directoryMode: '700'
 	})
 );

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ Overwrite existing destination file.
 
 ##### directoryMode
 
-Type: `number` | `string`\
+Type: `number`\
 Default: `0o777`
 
 Permissions for created directories.

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Overwrite existing destination file.
 Type: `number`\
 Default: `0o777`
 
-[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories.
+[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories. Not supported on Windows.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,13 @@ Default: `true`
 
 Overwrite existing destination file.
 
+##### directoryMode
+
+Type: `number` | `string`\
+Default: `0o777`
+
+Permissions for created directories.
+
 ## Related
 
 - [move-file-cli](https://github.com/sindresorhus/move-file-cli) - CLI for this module

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Overwrite existing destination file.
 Type: `number`\
 Default: `0o777`
 
-Permissions for created directories.
+[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories.
 
 ## Related
 

--- a/test/async.js
+++ b/test/async.js
@@ -34,3 +34,13 @@ test('overwrite option', async t => {
 		/The destination file exists/
 	);
 });
+
+test('directoryMode option', async t => {
+	const root = tempy.directory();
+	const directory = `${root}/dir`;
+	const destination = `${directory}/file`;
+	const directoryMode = 0o700;
+	await moveFile(tempWrite.sync(fixture), destination, {directoryMode});
+	const stat = fs.statSync(directory);
+	t.is(stat.mode & directoryMode, directoryMode);
+});

--- a/test/sync.js
+++ b/test/sync.js
@@ -35,3 +35,13 @@ test('overwrite option', t => {
 		moveFile.sync(tempWrite.sync('x'), tempWrite.sync('y'), {overwrite: false});
 	}, /The destination file exists/);
 });
+
+test('directoryMode option', t => {
+	const root = tempy.directory();
+	const directory = `${root}/dir`;
+	const destination = `${directory}/file`;
+	const directoryMode = 0o700;
+	moveFile.sync(tempWrite.sync(fixture), destination, {directoryMode});
+	const stat = fs.statSync(directory);
+	t.is(stat.mode & directoryMode, directoryMode);
+});


### PR DESCRIPTION
Adds an option `directoryMode` which enables controlling permissions of implicitly created directories.

Closes #13.